### PR TITLE
DON'T MERGE! CYB-560 one shot fix: clear dlogs in testnet

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -344,7 +344,7 @@ namespace eosiosystem {
    typedef eosio::multi_index< "refunds"_n, refund_request >      refunds_table;
 
 
-#ifdef DEBUG_MODE
+//~#ifdef DEBUG_MODE
    // some actions (like onblock()) do not allow to print anything, so we use this table for debugging
    struct [[eosio::table, eosio::contract("eosio.system")]] dlogs {
       std::vector<std::string> data; // array of log messages
@@ -352,7 +352,7 @@ namespace eosiosystem {
       EOSLIB_SERIALIZE( dlogs, (data) );
    };
    typedef eosio::singleton< "dlogs"_n, dlogs > dlogs_singleton;
-#endif // DEBUG_MODE
+//~#endif // DEBUG_MODE
 
    /**
     * The EOSIO system contract. The EOSIO system contract governs ram market, voters, producers, global state.
@@ -373,10 +373,10 @@ namespace eosiosystem {
          eosio_global_state4         _gstate4;
          rammarket                   _rammarket;
          contracts_version_singleton _contracts_version;
-#ifdef DEBUG_MODE
+//~#ifdef DEBUG_MODE
          dlogs                       _dlogs;
          dlogs_singleton             _dlogs_singleton;
-#endif // DEBUG_MODE
+//~#endif // DEBUG_MODE
 
       public:
          static constexpr eosio::name active_permission{"active"_n};

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -22,18 +22,18 @@ namespace eosiosystem {
       , _global4(get_self(), get_self().value)
       , _rammarket(get_self(), get_self().value)
       , _contracts_version(get_self(), get_self().value)
-#ifdef DEBUG_MODE
+//~#ifdef DEBUG_MODE
       , _dlogs_singleton(get_self(), get_self().value)
-#endif
+//~#endif
    {
       _gstate  = _global.exists() ? _global.get() : get_default_parameters();
       _gstate2 = _global2.exists() ? _global2.get() : eosio_global_state2{};
       _gstate3 = _global3.exists() ? _global3.get() : eosio_global_state3{};
       _gstate4 = _global4.exists() ? _global4.get() : eosio_global_state4{};
       _contracts_version.set(version_info{CONTRACTS_VERSION}, get_self());
-#ifdef DEBUG_MODE
+//~#ifdef DEBUG_MODE
       _dlogs = _dlogs_singleton.exists() ? _dlogs_singleton.get() : dlogs{};
-#endif
+//~#endif
    }
 
    eosio_global_state system_contract::get_default_parameters() {
@@ -52,9 +52,9 @@ namespace eosiosystem {
       _global2.set( _gstate2, get_self() );
       _global3.set( _gstate3, get_self() );
       _global4.set( _gstate4, get_self() );
-#ifdef DEBUG_MODE
+//~#ifdef DEBUG_MODE
       _dlogs_singleton.set(_dlogs, get_self());
-#endif
+//~#endif
    }
 
    void system_contract::setram( uint64_t max_ram_size ) {

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -13,6 +13,12 @@ namespace eosiosystem {
 
       require_auth(get_self());
 
+
+      // removed dlogs data from production
+      // TODO: remove
+      _dlogs.data.clear();
+
+
       block_timestamp timestamp;
       name producer;
       _ds >> timestamp >> producer;


### PR DESCRIPTION
Temporary changes to fix testnet persistent storage. Will be used only once with following revert to the current contracts.

Done.
```
# daobet-cli set contract eosio eosio.system/ eosio.system.wasm eosio.system.abi 
Reading WASM from /root/contracts/eosio.system/eosio.system.wasm...
Publishing contract...
executed transaction: ab369352d07c0dfd43fbb3c6cca755e0d086c1ea7a57d25f8c85862f8eebc3da  56408 bytes  14402 us
#         eosio <= eosio::setcode               {"account":"eosio","vmtype":0,"vmversion":0,"code":"0061736d010000000197033a60000060047f7f7f7f006002...
#         eosio <= eosio::setabi                {"account":"eosio","abi":"0e656f73696f3a3a6162692f312e31003d086162695f686173680002056f776e6572046e61...
warning: transaction executed locally, but may not be confirmed by the network yet         ] 

# daobet-cli get table eosio eosio dlogs
{
  "rows": [{
      "data": []
    }
  ],
  "more": false
}

# daobet-cli set contract eosio contracts-v1.2.2/eosio.system/ eosio.system.wasm eosio.system.abi 
Reading WASM from /root/contracts/contracts-v1.2.2/eosio.system/eosio.system.wasm...
Publishing contract...
executed transaction: 56793881663f5dbf2385a31235e39813615ee0f1b06817054d4fe6c5c668a96a  48864 bytes  10607 us
#         eosio <= eosio::setcode               {"account":"eosio","vmtype":0,"vmversion":0,"code":"0061736d0100000001fe023860000060027f7f0060037f7f...
#         eosio <= eosio::setabi                {"account":"eosio","abi":"0e656f73696f3a3a6162692f312e31003c086162695f686173680002056f776e6572046e61...
warning: transaction executed locally, but may not be confirmed by the network yet         ] 

# daobet-cli get table eosio eosio version
{
  "rows": [{
      "version": "v1.2.2"
    }
  ],
  "more": false
}
```