### PR TITLE
temp fix: make zero min activated stake

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -75,7 +75,7 @@ namespace eosiosystem {
    static constexpr int64_t  min_pervote_daily_pay = 100'0000;
    static constexpr uint32_t refund_delay_sec      = 14 * seconds_per_day; ///< DAO: stake lock up period = 2 weeks
 
-   static constexpr int64_t  min_producer_activated_stake = 30'000'0000;   ///< minimum activated stake
+   static constexpr int64_t  min_producer_activated_stake = 0;   ///< minimum activated stake
 
    /**
     * eosio.system contract defines the structures and actions needed for blockchain's core functionality.


### PR DESCRIPTION
This change temporarily disables `min_activated_stake` calculation logic until it is fixed (external votes are not included in total votes sum).